### PR TITLE
feat(title): improve list title editing accessibility and mobile ux

### DIFF
--- a/src/components/ListTitle.tsx
+++ b/src/components/ListTitle.tsx
@@ -1,30 +1,51 @@
+import { MutableRefObject, useEffect, useRef } from "react";
+
 const ListTitle = ({
   title,
   setEditTitle,
+  focusRef,
 }: {
   title: string;
   setEditTitle: (value: boolean) => void;
+  focusRef?: MutableRefObject<boolean>;
 }) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (focusRef?.current && buttonRef.current) {
+      buttonRef.current.focus();
+      focusRef.current = false;
+    }
+  }, [focusRef]);
+
   return (
     <div className="home-titleContainer">
-      <span
-        className="home-title"
-        onDoubleClick={() => setEditTitle(true)}
-        title={title}
-      >
-        {title}
-      </span>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
+      <h1 className="home-title-wrapper">
+        <button
+          ref={buttonRef}
+          className="home-title"
+          onClick={() => setEditTitle(true)}
+          aria-label={`Edit list title: ${title}`}
+        >
+          {title}
+        </button>
+      </h1>
+      <button
         className="home-editTitleButton"
         onClick={() => setEditTitle(true)}
+        aria-label="Edit title"
       >
-        <path
-          fill="currentColor"
-          d="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
-        />
-      </svg>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            fill="currentColor"
+            d="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
+          />
+        </svg>
+      </button>
     </div>
   );
 };

--- a/src/components/ListTitleEdit.tsx
+++ b/src/components/ListTitleEdit.tsx
@@ -1,13 +1,12 @@
 import { List } from "@router/listing";
 import { useMutation } from "@tanstack/react-query";
-import { ChangeEvent, RefObject } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "react-toastify";
 import { trpc } from "src/utils/trpc";
 
 const ListTitleEdit = ({
   title,
   setTitle,
-  textAreaRef,
   data,
   listLabel,
   oldTitle,
@@ -16,56 +15,110 @@ const ListTitleEdit = ({
 }: {
   title: string;
   setTitle: (value: string) => void;
-  textAreaRef: RefObject<HTMLTextAreaElement | null>;
   data: Partial<List>;
   listLabel: string;
   oldTitle: string | undefined;
   setOldTitle: (value: string) => void;
   setEditTitle: (value: boolean) => void;
 }) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
   const updateTitle = useMutation({
     ...trpc.listing.updateTitle.mutationOptions(),
     onSuccess: () => {
       toast.success("Successfully updated link to list.");
+      setEditTitle(false);
     },
     onError: () => {
       toast.error("Unable to update the list.");
     },
   });
 
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  const handleSave = () => {
+    const trimmedTitle = title.trim();
+    if (trimmedTitle === "") {
+      setError("Title cannot be empty");
+      return;
+    }
+
+    if (trimmedTitle === oldTitle) {
+      setEditTitle(false);
+      return;
+    }
+
+    const labelToUse = data && data.label ? data.label : listLabel;
+    if (labelToUse) {
+      updateTitle.mutate({ label: labelToUse, title: trimmedTitle });
+      setOldTitle(trimmedTitle);
+    } else {
+      setEditTitle(false);
+    }
+  };
+
+  const handleCancel = () => {
+    if (oldTitle) setTitle(oldTitle);
+    else setTitle("misorter");
+    setEditTitle(false);
+  };
+
   return (
-    <textarea
-      autoFocus
-      className="home-editTitle"
-      value={title}
-      ref={textAreaRef}
-      onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {
-        setTitle(e.target.value);
-      }}
-      onBlur={() => setEditTitle(false)}
-      onFocus={(e) =>
-        e.currentTarget.setSelectionRange(
-          e.currentTarget.value.length,
-          e.currentTarget.value.length
-        )
-      }
-      onKeyDown={(e) => {
-        if (e.code === "Enter" || e.code === "Escape") {
-          e.preventDefault();
-          e.stopPropagation();
-          if (title === "") {
-            setTitle("misorter");
-          }
-          // Try to use data.label first, fall back to listLabel if data not loaded
-          const labelToUse = data && data.label ? data.label : listLabel;
-          if (labelToUse && title !== oldTitle) {
-            updateTitle.mutate({ label: labelToUse, title });
-            setOldTitle(title);
-          }
-          setEditTitle(false);
-        }
-      }}
-    />
+    <div className="home-editTitleForm">
+      <div className="home-inputWrapper">
+        <input
+          ref={inputRef}
+          className={`home-editTitleInput ${error ? "home-inputError" : ""}`}
+          value={title}
+          onChange={(e) => {
+            setTitle(e.target.value);
+            if (error) setError(null);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleSave();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              handleCancel();
+            }
+          }}
+          disabled={updateTitle.isPending}
+          aria-label="Edit list title"
+          aria-invalid={!!error}
+          aria-describedby={error ? "title-error" : undefined}
+        />
+        {error && (
+          <span id="title-error" className="home-inputErrorMessage">
+            {error}
+          </span>
+        )}
+      </div>
+      <div className="home-editActions">
+        <button
+          className="home-editAction home-editSave"
+          onClick={handleSave}
+          disabled={updateTitle.isPending}
+          aria-label="Save title"
+        >
+          Save
+        </button>
+        <button
+          className="home-editAction home-editCancel"
+          onClick={handleCancel}
+          disabled={updateTitle.isPending}
+          aria-label="Cancel edit"
+        >
+          Cancel
+        </button>
+      </div>
+      <p className="home-editHelper">Enter to save, Esc to cancel</p>
+    </div>
   );
 };
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -14,9 +14,7 @@ import { trpc } from "@utils/trpc";
 import { v4 as uuidv4 } from "uuid";
 
 const tip =
-  "hitting <b>no opinion</b>  or  <b>I like both</b> frequently will negatively affect your results.";
-
-const MIN_TEXTAREA_HEIGHT = 32;
+  "Tap the title to name your list something.<br/>hitting <b>no opinion</b>  or  <b>I like both</b> frequently will negatively affect your results.";
 
 export type ListItem = {
   id: string;
@@ -52,11 +50,11 @@ function Home() {
   const [initialListSize, setInititalListSize] = useState<number>(-1);
   const [currentListData, setCurrentListData] = useState<Partial<List>>({});
 
+  const focusTitleRef = useRef(false);
+
   // Featured Lists
   const [selectedList, setSelectedList] = useState<string>("");
   const [open, setOpen] = useState(false);
-
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   const { data, isFetching, refetch } = useQuery({
     ...trpc.listing.get.queryOptions({ label: listLabel ?? "" }),
@@ -129,16 +127,6 @@ function Home() {
     }
   }, [data, data?.items, data?.title, updateList]);
 
-  useEffect(() => {
-    if (textAreaRef.current) {
-      textAreaRef.current.style.height = "inherit";
-      textAreaRef.current.style.height = `${Math.max(
-        textAreaRef.current.scrollHeight,
-        MIN_TEXTAREA_HEIGHT
-      )}px`;
-    }
-  }, [title]);
-
   return (
     <div className="home-container">
       <main className="home-main">
@@ -146,7 +134,6 @@ function Home() {
           <ListTitleEdit
             title={title}
             setTitle={setTitle}
-            textAreaRef={textAreaRef}
             data={currentListData}
             listLabel={listLabel ?? ""}
             oldTitle={oldTitle}
@@ -154,7 +141,14 @@ function Home() {
             setEditTitle={setEditTitle}
           />
         ) : (
-          <ListTitle title={title} setEditTitle={setEditTitle} />
+          <ListTitle
+            title={title}
+            setEditTitle={(val) => {
+              if (val) focusTitleRef.current = true;
+              setEditTitle(val);
+            }}
+            focusRef={focusTitleRef}
+          />
         )}
         <div className="home-tipContainer">
           <p className="home-tip" dangerouslySetInnerHTML={{ __html: tip }} />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -197,9 +197,11 @@ html[data-theme="light"] {
 
 html[data-theme="dark"] {
   --color-text-primary: hsl(0, 0%, 95%);
+  --color-text-secondary: hsl(0, 0%, 70%);
   --color-bg-primary: #121212;
   --color-bg-secondary: #202020;
   --color-bg-tertiary: #313131;
+  --color-bg-icon: #333333;
   --md-shadow-dp1:
     0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.12),
     0 1px 5px 0 rgba(0, 0, 0, 0.2);
@@ -558,17 +560,28 @@ html[data-theme="dark"] .featuredLists-try:hover {
 
 .home-editTitleButton {
   color: var(--color-bg-primary);
-  height: 1.75rem;
-  width: 1.75rem;
+  height: 2.5rem;
+  width: 2.5rem;
   position: absolute;
-  top: 0;
+  top: 50%;
   right: 0;
-  translate: 100%;
+  translate: 100% -50%;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem;
+  border-radius: 0.65rem;
 }
 
 .home-titleContainer:hover > .home-editTitleButton:hover {
   background: var(--color-bg-secondary);
+}
+
+.home-title-wrapper {
+  margin: 0;
+  padding: 0;
+  display: inline-block;
 }
 
 .home-title {
@@ -576,7 +589,34 @@ html[data-theme="dark"] .featuredLists-try:hover {
   font-size: 2.25rem;
   margin: 0;
   line-height: 1.5;
-  cursor: text;
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid transparent;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+  display: inline-block;
+  text-align: center;
+}
+
+.home-title:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.home-title:focus-visible {
+  outline: 2px solid var(--color-text-once);
+  outline-offset: 2px;
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.home-editTitleButton:focus-visible {
+  outline: 2px solid var(--color-text-once);
+  outline-offset: 2px;
+  border-radius: 0.65rem;
+  opacity: 1;
+  translate: 100%;
 }
 
 .home-title a:hover,
@@ -591,6 +631,107 @@ html[data-theme="dark"] .featuredLists-try:hover {
   text-align: center;
 }
 
+.home-editTitleForm {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  max-width: 75%;
+}
+
+.home-inputWrapper {
+  width: 100%;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.home-editTitleInput {
+  font-size: 2.25rem;
+  margin: 0;
+  border: 1px solid var(--color-bg-secondary);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  border-radius: 0.65rem;
+  width: 100%;
+  padding: 0.25rem 0.5rem;
+  outline: none;
+  text-align: center;
+  font-family: inherit;
+}
+
+.home-editTitleInput:focus {
+  border-color: var(--color-text-once);
+  box-shadow: 0 0 0 2px rgba(255, 95, 162, 0.2);
+}
+
+.home-inputError {
+  border-color: #cd7e81;
+}
+
+.home-inputErrorMessage {
+  color: #cd7e81;
+  font-size: 0.85rem;
+  margin-top: 0.25rem;
+  font-weight: 500;
+}
+
+.home-editActions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.home-editAction {
+  font-size: 1rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  transition:
+    opacity 0.2s,
+    transform 0.1s;
+  min-width: 44px; /* Accessible touch target */
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.home-editAction:active {
+  transform: scale(0.96);
+}
+
+.home-editSave {
+  background: var(--color-text-once);
+  color: white;
+}
+
+.home-editSave:hover {
+  background: var(--color-once-hover);
+}
+
+.home-editCancel {
+  background: transparent;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-bg-icon);
+}
+
+.home-editCancel:hover {
+  background: var(--color-bg-icon);
+}
+
+.home-editHelper {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  margin: 0;
+  opacity: 0.8;
+}
+
+/* Remove old textarea styles if no longer used, or keep for safety */
 .home-editTitle {
   font-size: 2.25rem;
   margin: 0;
@@ -812,11 +953,27 @@ html[data-theme="light"] .home-listInput {
     max-width: 99vw;
   }
 
-  .home-editTitleButton {
-    height: 1rem;
-    width: 1rem;
+  .home-editHelper {
+    display: none;
   }
 
+  .home-editTitleButton {
+    height: 2.75rem;
+    width: 2.75rem;
+    color: var(--color-text-once);
+    opacity: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    top: -0.6rem;
+  }
+
+  .home-editTitleButton svg {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  .home-editTitleInput,
   .home-editTitle {
     font-size: 1.25rem;
   }
@@ -1734,6 +1891,25 @@ html[data-theme="dark"] .notice-banner-success {
 
 html[data-theme="dark"] .notice-banner-success .notice-banner-dismiss:hover {
   background: rgba(0, 0, 0, 0.1);
+}
+
+html[data-theme="dark"] .home-editTitleInput {
+  color: var(--color-text-primary);
+  background: var(--color-bg-secondary);
+  border-color: var(--color-bg-tertiary);
+}
+
+html[data-theme="dark"] .home-editCancel {
+  color: var(--color-text-primary);
+  border-color: var(--color-text-secondary);
+}
+
+html[data-theme="dark"] .home-editCancel:hover {
+  background: var(--color-bg-tertiary);
+}
+
+html[data-theme="dark"] .home-editHelper {
+  color: var(--color-text-secondary);
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
- Add semantic <button> elements for better keyboard/screen reader support
- Increase touch targets to 44px minimum for mobile accessibility
- Implement explicit Save/Cancel buttons in edit mode
- Add always-visible edit indicator on mobile (pink pencil icon)
- Improve focus management (focus returns to trigger after edit)
- Add dark mode support for all UI elements (Cancel button, helper text)
- Hide keyboard helper text on mobile devices
- Add onboarding tip for title editing feature
- Add comprehensive :focus-visible styles for keyboard navigation

Resolves mobile discoverability issue where edit icon was hover-only. Implements WCAG 2.1 AA accessibility standards for form controls.